### PR TITLE
Add aggregate by patron menu

### DIFF
--- a/src/components/AggregateCriteria/AggregateCriteriaCard.test.tsx
+++ b/src/components/AggregateCriteria/AggregateCriteriaCard.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { Form } from 'react-final-form';
+import withIntlConfiguration from '../../test/util/withIntlConfiguration';
+import AggregateCriteriaCard from './AggregateCriteriaCard';
+import { CriteriaAggregateType } from '../../types/CriteriaTypes';
+
+describe('Aggregate criteria card', () => {
+  const submitter = jest.fn();
+
+  beforeEach(() => {
+    render(
+      withIntlConfiguration(
+        <Form onSubmit={(v) => submitter(v)}>
+          {({ handleSubmit }) => (
+            <form onSubmit={handleSubmit}>
+              <AggregateCriteriaCard />
+              <button type="submit">Submit</button>
+            </form>
+          )}
+        </Form>
+      )
+    );
+  });
+
+  it('Treats pass as default', async () => {
+    expect(screen.getByRole('combobox', { name: 'Filter type' })).toHaveValue(
+      CriteriaAggregateType.PASS
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(submitter).toHaveBeenCalledWith({
+      aggregateFilter: {
+        type: CriteriaAggregateType.PASS,
+      },
+    });
+  });
+
+  it('Pass has no extra boxes/options', async () => {
+    await userEvent.selectOptions(
+      screen.getByRole('combobox', { name: 'Filter type' }),
+      CriteriaAggregateType.PASS
+    );
+
+    expect(
+      screen.queryByRole('combobox', { name: 'Comparison operator' })
+    ).toBeNull();
+    expect(screen.queryByRole('spinbutton')).toBeNull();
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  it('Quantity has operator and dollar amount', async () => {
+    await userEvent.selectOptions(
+      screen.getByRole('combobox', { name: 'Filter type' }),
+      CriteriaAggregateType.NUM_ROWS
+    );
+
+    // find to allow for useField hook to update
+    expect(
+      await screen.findByRole('combobox', { name: 'Comparison operator' })
+    ).toBeVisible();
+    expect(screen.getByRole('spinbutton')).toBeVisible();
+
+    await userEvent.selectOptions(
+      screen.getByRole('combobox', { name: 'Comparison operator' }),
+      'Less than but not equal to'
+    );
+    await userEvent.type(screen.getByRole('spinbutton'), '15');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(submitter).toHaveBeenCalledWith({
+      aggregateFilter: {
+        type: CriteriaAggregateType.NUM_ROWS,
+        operator: 'LESS_THAN',
+        amount: '15',
+      },
+    });
+  });
+
+  it('Amount has operator and dollar amount', async () => {
+    await userEvent.selectOptions(
+      screen.getByRole('combobox', { name: 'Filter type' }),
+      CriteriaAggregateType.TOTAL_AMOUNT
+    );
+
+    // find to allow for useField hook to update
+    expect(
+      await screen.findByRole('combobox', { name: 'Comparison operator' })
+    ).toBeVisible();
+    expect(screen.getByRole('spinbutton')).toBeVisible();
+
+    await userEvent.selectOptions(
+      screen.getByRole('combobox', { name: 'Comparison operator' }),
+      'Greater than or equal to'
+    );
+    await userEvent.type(screen.getByRole('spinbutton'), '10');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(submitter).toHaveBeenCalledWith({
+      aggregateFilter: {
+        type: CriteriaAggregateType.TOTAL_AMOUNT,
+        operator: 'GREATER_THAN_EQUAL',
+        amountDollars: '10.00',
+      },
+    });
+  });
+});

--- a/src/components/AggregateCriteria/AggregateCriteriaCard.tsx
+++ b/src/components/AggregateCriteria/AggregateCriteriaCard.tsx
@@ -1,0 +1,104 @@
+import { Card, Col, Row, Select, TextField } from '@folio/stripes/components';
+import React from 'react';
+import { CriteriaAggregateType } from '../../types/CriteriaTypes';
+import { Field, useField } from 'react-final-form';
+import OperatorSelect from '../Criteria/OperatorSelect';
+import useMonetaryOnBlur from '../../utils/useMonetaryOnBlur';
+
+export default function AggregateCriteriaCard() {
+  const selectedType = useField<CriteriaAggregateType>('aggregateFilter.type', {
+    subscription: { value: true },
+    format: (value) => value ?? CriteriaAggregateType.PASS,
+  }).input.value;
+
+  const monetaryOnBlur = useMonetaryOnBlur('aggregateFilter.amountDollars');
+
+  return (
+    <Card headerStart="Only include patrons with:">
+      <Row>
+        <Col xs={12} md={4}>
+          <Field
+            name="aggregateFilter.type"
+            defaultValue={CriteriaAggregateType.PASS}
+          >
+            {(fieldProps) => (
+              <Select<CriteriaAggregateType>
+                {...fieldProps}
+                fullWidth
+                marginBottom0
+                required
+                label="Filter type"
+                dataOptions={[
+                  {
+                    label: 'None (include all patrons)',
+                    value: CriteriaAggregateType.PASS,
+                  },
+                  {
+                    label: 'Number of accounts',
+                    value: CriteriaAggregateType.NUM_ROWS,
+                  },
+                  {
+                    label: 'Total amount',
+                    value: CriteriaAggregateType.TOTAL_AMOUNT,
+                  },
+                ]}
+              />
+            )}
+          </Field>
+        </Col>
+
+        {selectedType !== CriteriaAggregateType.PASS && (
+          <Col xs={12} md={4}>
+            <OperatorSelect name="aggregateFilter.operator" />
+          </Col>
+        )}
+
+        {selectedType === CriteriaAggregateType.NUM_ROWS && (
+          <Col xs={12} md={4}>
+            <Field name="aggregateFilter.amount">
+              {(fieldProps) => (
+                <TextField<number>
+                  {...fieldProps}
+                  fullWidth
+                  marginBottom0
+                  required
+                  type="number"
+                  label="Number of accounts"
+                  min={1}
+                  step={1}
+                />
+              )}
+            </Field>
+          </Col>
+        )}
+
+        {selectedType === CriteriaAggregateType.TOTAL_AMOUNT && (
+          <Col xs={12} md={4}>
+            <Field name="aggregateFilter.amountDollars">
+              {(fieldProps) => (
+                <TextField<number>
+                  {...fieldProps}
+                  fullWidth
+                  marginBottom0
+                  required
+                  type="number"
+                  label="Amount"
+                  min={0}
+                  step={0.01}
+                  onBlur={monetaryOnBlur}
+                />
+              )}
+            </Field>
+          </Col>
+        )}
+      </Row>
+
+      <p style={{ marginBottom: 0 }}>
+        <i>
+          This will be applied after accounts are evaluated per the
+          &ldquo;Criteria&rdquo; specified above.
+        </i>
+      </p>
+    </Card>
+  );
+}

--- a/src/components/ConditionalCard.test.tsx
+++ b/src/components/ConditionalCard.test.tsx
@@ -5,9 +5,9 @@ import React from 'react';
 import { Form } from 'react-final-form';
 import withIntlConfiguration from '../test/util/withIntlConfiguration';
 import {
-  CriteriaCardTerminalType,
+  CriteriaTerminalType,
   ComparisonOperator,
-  CriteriaCardGroupType,
+  CriteriaGroupType,
 } from '../types/CriteriaTypes';
 import { DataTokenType } from '../types/TokenTypes';
 import DataTokenCardBody from './Token/Data/DataTokenCardBody';
@@ -26,12 +26,12 @@ describe('Conditional card (via constant conditional)', () => {
                 type: DataTokenType.CONSTANT_CONDITIONAL,
                 conditions: [
                   {
-                    type: CriteriaCardTerminalType.AGE,
+                    type: CriteriaTerminalType.AGE,
                     numDays: '10',
                     value: 'if value 1',
                   },
                   {
-                    type: CriteriaCardTerminalType.AMOUNT,
+                    type: CriteriaTerminalType.AMOUNT,
                     operator: ComparisonOperator.GREATER_THAN,
                     amountDollars: '20',
                     value: 'if value 2',
@@ -64,7 +64,7 @@ describe('Conditional card (via constant conditional)', () => {
           type: DataTokenType.CONSTANT_CONDITIONAL,
           conditions: [
             {
-              type: CriteriaCardTerminalType.AGE,
+              type: CriteriaTerminalType.AGE,
               numDays: '10',
               value: 'if value 1',
             },
@@ -86,13 +86,13 @@ describe('Conditional card (via constant conditional)', () => {
           type: DataTokenType.CONSTANT_CONDITIONAL,
           conditions: [
             {
-              type: CriteriaCardTerminalType.AMOUNT,
+              type: CriteriaTerminalType.AMOUNT,
               operator: ComparisonOperator.GREATER_THAN,
               amountDollars: '20',
               value: 'if value 2',
             },
             {
-              type: CriteriaCardTerminalType.AGE,
+              type: CriteriaTerminalType.AGE,
               numDays: '10',
               value: 'if value 1',
             },
@@ -114,13 +114,13 @@ describe('Conditional card (via constant conditional)', () => {
           type: DataTokenType.CONSTANT_CONDITIONAL,
           conditions: [
             {
-              type: CriteriaCardTerminalType.AMOUNT,
+              type: CriteriaTerminalType.AMOUNT,
               operator: ComparisonOperator.GREATER_THAN,
               amountDollars: '20',
               value: 'if value 2',
             },
             {
-              type: CriteriaCardTerminalType.AGE,
+              type: CriteriaTerminalType.AGE,
               numDays: '10',
               value: 'if value 1',
             },

--- a/src/components/ConditionalCard.tsx
+++ b/src/components/ConditionalCard.tsx
@@ -7,11 +7,13 @@ export default function ConditionalCard({
   children,
   conditionName,
   fieldArrayName,
+  patronOnly = false,
   index,
 }: {
   children: ReactNode;
   conditionName: string;
   fieldArrayName: string;
+  patronOnly?: boolean;
   index: number;
 }) {
   const { fields } = useFieldArray(fieldArrayName);
@@ -35,7 +37,7 @@ export default function ConditionalCard({
         </>
       }
     >
-      <CriteriaCard name={conditionName} alone />
+      <CriteriaCard name={conditionName} alone patronOnly={patronOnly} />
       {children}
     </Card>
   );

--- a/src/components/Criteria/CriteriaAge.test.tsx
+++ b/src/components/Criteria/CriteriaAge.test.tsx
@@ -27,7 +27,7 @@ it('Age criteria displays appropriate form', async () => {
   );
 
   await userEvent.selectOptions(screen.getByRole('combobox'), 'Age');
-  await userEvent.type(screen.getByRole('textbox'), '10');
+  await userEvent.type(screen.getByRole('spinbutton'), '10');
   await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
 
   expect(submitter).toHaveBeenCalledWith({

--- a/src/components/Criteria/CriteriaAge.tsx
+++ b/src/components/Criteria/CriteriaAge.tsx
@@ -12,8 +12,10 @@ export default function CriteriaAge({ prefix }: { prefix: string }) {
             fullWidth
             marginBottom0
             required
+            type="number"
             label="Older than (days)"
             min={1}
+            step={1}
           />
         )}
       </Field>

--- a/src/components/Criteria/CriteriaCard.pass.test.tsx
+++ b/src/components/Criteria/CriteriaCard.pass.test.tsx
@@ -7,12 +7,10 @@ import FormValues from '../../types/FormValues';
 import withIntlConfiguration from '../../test/util/withIntlConfiguration';
 import CriteriaCard from './CriteriaCard';
 
-const noop = () => ({});
-
 it('Criteria card with "no criteria" should be empty', async () => {
   const { container } = render(
     withIntlConfiguration(
-      <Form<FormValues> mutators={{ ...arrayMutators }} onSubmit={noop}>
+      <Form<FormValues> mutators={{ ...arrayMutators }} onSubmit={jest.fn()}>
         {() => <CriteriaCard name="criteria" root alone />}
       </Form>
     )

--- a/src/components/Criteria/CriteriaCard.tsx
+++ b/src/components/Criteria/CriteriaCard.tsx
@@ -21,11 +21,13 @@ export default function CriteriaCard({
   name,
   onRemove,
   root = false,
+  patronOnly = false,
   alone,
 }: {
   name: string;
   onRemove?: () => void;
   root?: boolean;
+  patronOnly?: boolean;
   alone: boolean;
 }) {
   const type = useField<CriteriaGroupType | CriteriaTerminalType>(
@@ -105,7 +107,13 @@ export default function CriteriaCard({
     <Card
       cardClass={css.cardClass}
       headerClass={css.headerClass}
-      headerStart={<CriteriaCardSelect name={`${name}.type`} root={root} />}
+      headerStart={
+        <CriteriaCardSelect
+          name={`${name}.type`}
+          root={root}
+          patronOnly={patronOnly}
+        />
+      }
       headerEnd={
         <CriteriaCardToolbox
           prefix={`${name}.`}

--- a/src/components/Criteria/CriteriaCard.tsx
+++ b/src/components/Criteria/CriteriaCard.tsx
@@ -4,8 +4,8 @@ import React, { useMemo } from 'react';
 import { useField } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
 import {
-  CriteriaCardGroupType,
-  CriteriaCardTerminalType,
+  CriteriaGroupType,
+  CriteriaTerminalType,
 } from '../../types/CriteriaTypes';
 import CriteriaAge from './CriteriaAge';
 import CriteriaAmount from './CriteriaAmount';
@@ -28,22 +28,22 @@ export default function CriteriaCard({
   root?: boolean;
   alone: boolean;
 }) {
-  const type = useField<CriteriaCardGroupType | CriteriaCardTerminalType>(
+  const type = useField<CriteriaGroupType | CriteriaTerminalType>(
     `${name}.type`,
     {
       subscription: { value: true },
-      format: (value) => value ?? CriteriaCardTerminalType.PASS,
+      format: (value) => value ?? CriteriaTerminalType.PASS,
     }
   ).input.value;
 
   const cardInterior = useMemo(() => {
     switch (type) {
-      case CriteriaCardTerminalType.PASS:
+      case CriteriaTerminalType.PASS:
         return <div />;
 
-      case CriteriaCardGroupType.ALL_OF:
-      case CriteriaCardGroupType.ANY_OF:
-      case CriteriaCardGroupType.NONE_OF:
+      case CriteriaGroupType.ALL_OF:
+      case CriteriaGroupType.ANY_OF:
+      case CriteriaGroupType.NONE_OF:
         return (
           <FieldArray name={`${name}.criteria`}>
             {({ fields }) =>
@@ -59,37 +59,37 @@ export default function CriteriaCard({
           </FieldArray>
         );
 
-      case CriteriaCardTerminalType.AGE:
+      case CriteriaTerminalType.AGE:
         return (
           <Row>
             <CriteriaAge prefix={`${name}.`} />
           </Row>
         );
-      case CriteriaCardTerminalType.AMOUNT:
+      case CriteriaTerminalType.AMOUNT:
         return (
           <Row>
             <CriteriaAmount prefix={`${name}.`} />
           </Row>
         );
-      case CriteriaCardTerminalType.FEE_FINE_TYPE:
+      case CriteriaTerminalType.FEE_FINE_TYPE:
         return (
           <Row>
             <CriteriaFeeFineType prefix={`${name}.`} />
           </Row>
         );
-      case CriteriaCardTerminalType.LOCATION:
+      case CriteriaTerminalType.LOCATION:
         return (
           <Row>
             <CriteriaLocation prefix={`${name}.`} />
           </Row>
         );
-      case CriteriaCardTerminalType.SERVICE_POINT:
+      case CriteriaTerminalType.SERVICE_POINT:
         return (
           <Row>
             <CriteriaServicePoint prefix={`${name}.`} />
           </Row>
         );
-      case CriteriaCardTerminalType.PATRON_GROUP:
+      case CriteriaTerminalType.PATRON_GROUP:
         return (
           <Row>
             <CriteriaPatronGroup prefix={`${name}.`} />
@@ -115,7 +115,7 @@ export default function CriteriaCard({
         />
       }
       bodyClass={classNames({
-        [css.emptyBody]: type === CriteriaCardTerminalType.PASS,
+        [css.emptyBody]: type === CriteriaTerminalType.PASS,
       })}
     >
       {cardInterior}

--- a/src/components/Criteria/CriteriaCard.unknown.test.tsx
+++ b/src/components/Criteria/CriteriaCard.unknown.test.tsx
@@ -5,14 +5,12 @@ import { Form } from 'react-final-form';
 import withIntlConfiguration from '../../test/util/withIntlConfiguration';
 import CriteriaCard from './CriteriaCard';
 
-const noop = () => ({});
-
 it('Criteria card with unknown type should display loading', () => {
   const { container } = render(
     withIntlConfiguration(
       <Form
         mutators={{ ...arrayMutators }}
-        onSubmit={noop}
+        onSubmit={jest.fn()}
         initialValues={{ criteria: { type: 'foobar' } }}
       >
         {() => <CriteriaCard name="criteria" root alone />}

--- a/src/components/Criteria/CriteriaCardSelect.test.tsx
+++ b/src/components/Criteria/CriteriaCardSelect.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { Form } from 'react-final-form';
+import CriteriaCardSelect from './CriteriaCardSelect';
+import React from 'react';
+
+describe('Criteria card selection box', () => {
+  it('root has no criteria option', () => {
+    render(
+      <Form onSubmit={jest.fn()}>
+        {() => <CriteriaCardSelect name="test" root />}
+      </Form>
+    );
+
+    expect(
+      screen.getByRole('option', { name: 'No criteria (always run)' })
+    ).toBeInTheDocument();
+  });
+
+  it('non patron-only has item/etc options', () => {
+    render(
+      <Form onSubmit={jest.fn()}>
+        {() => <CriteriaCardSelect name="test" />}
+      </Form>
+    );
+
+    expect(screen.getByRole('option', { name: 'All of:' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: 'Item location' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: 'Patron group' })
+    ).toBeInTheDocument();
+  });
+
+  it('patron-only does not have item/etc options', () => {
+    render(
+      <Form onSubmit={jest.fn()}>
+        {() => <CriteriaCardSelect name="test" patronOnly />}
+      </Form>
+    );
+
+    expect(screen.getByRole('option', { name: 'All of:' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Item location' })).toBeNull();
+    expect(
+      screen.getByRole('option', { name: 'Patron group' })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/Criteria/CriteriaCardSelect.tsx
+++ b/src/components/Criteria/CriteriaCardSelect.tsx
@@ -2,8 +2,8 @@ import { Select, SelectOptionType } from '@folio/stripes/components';
 import React, { useMemo } from 'react';
 import { Field } from 'react-final-form';
 import {
-  CriteriaCardGroupType,
-  CriteriaCardTerminalType,
+  CriteriaGroupType,
+  CriteriaTerminalType,
 } from '../../types/CriteriaTypes';
 
 export default function CriteriaCardSelect({
@@ -15,66 +15,66 @@ export default function CriteriaCardSelect({
 }) {
   const selectDefaultValue = useMemo(() => {
     if (root) {
-      return CriteriaCardTerminalType.PASS;
+      return CriteriaTerminalType.PASS;
     } else {
-      return CriteriaCardGroupType.ALL_OF;
+      return CriteriaGroupType.ALL_OF;
     }
   }, [root]);
 
   const selectOptions = useMemo(() => {
     const options: SelectOptionType<
-      CriteriaCardGroupType | CriteriaCardTerminalType
+      CriteriaGroupType | CriteriaTerminalType
     >[] = [
       {
         label: 'All of:',
-        value: CriteriaCardGroupType.ALL_OF,
+        value: CriteriaGroupType.ALL_OF,
       },
       {
         label: 'Any of:',
-        value: CriteriaCardGroupType.ANY_OF,
+        value: CriteriaGroupType.ANY_OF,
       },
       {
         label: 'None of:',
-        value: CriteriaCardGroupType.NONE_OF,
+        value: CriteriaGroupType.NONE_OF,
       },
 
       {
         label: '',
-        value: CriteriaCardTerminalType.PASS,
+        value: CriteriaTerminalType.PASS,
         disabled: true,
       },
 
       // TODO: sort these alphabetically per i18n
       {
         label: 'Age',
-        value: CriteriaCardTerminalType.AGE,
+        value: CriteriaTerminalType.AGE,
       },
       {
         label: 'Amount',
-        value: CriteriaCardTerminalType.AMOUNT,
+        value: CriteriaTerminalType.AMOUNT,
       },
       {
         label: 'Fee/fine type',
-        value: CriteriaCardTerminalType.FEE_FINE_TYPE,
+        value: CriteriaTerminalType.FEE_FINE_TYPE,
       },
       {
         label: 'Item location',
-        value: CriteriaCardTerminalType.LOCATION,
+        value: CriteriaTerminalType.LOCATION,
       },
       {
         label: 'Item service point',
-        value: CriteriaCardTerminalType.SERVICE_POINT,
+        value: CriteriaTerminalType.SERVICE_POINT,
       },
       {
         label: 'Patron group',
-        value: CriteriaCardTerminalType.PATRON_GROUP,
+        value: CriteriaTerminalType.PATRON_GROUP,
       },
     ];
 
     if (root) {
       options.unshift({
         label: 'No criteria (always run)',
-        value: CriteriaCardTerminalType.PASS,
+        value: CriteriaTerminalType.PASS,
       });
     }
 
@@ -84,7 +84,7 @@ export default function CriteriaCardSelect({
   return (
     <Field name={name} defaultValue={selectDefaultValue}>
       {(fieldProps) => (
-        <Select<CriteriaCardGroupType | CriteriaCardTerminalType>
+        <Select<CriteriaGroupType | CriteriaTerminalType>
           {...fieldProps}
           required
           marginBottom0

--- a/src/components/Criteria/CriteriaCardSelect.tsx
+++ b/src/components/Criteria/CriteriaCardSelect.tsx
@@ -8,11 +8,11 @@ import {
 
 export default function CriteriaCardSelect({
   name,
-  root,
+  root = false,
   patronOnly = false,
 }: {
   name: string;
-  root: boolean;
+  root?: boolean;
   patronOnly?: boolean;
 }) {
   const selectDefaultValue = useMemo(() => {

--- a/src/components/Criteria/CriteriaCardSelect.tsx
+++ b/src/components/Criteria/CriteriaCardSelect.tsx
@@ -9,9 +9,11 @@ import {
 export default function CriteriaCardSelect({
   name,
   root,
+  patronOnly = false,
 }: {
   name: string;
   root: boolean;
+  patronOnly?: boolean;
 }) {
   const selectDefaultValue = useMemo(() => {
     if (root) {
@@ -45,26 +47,30 @@ export default function CriteriaCardSelect({
       },
 
       // TODO: sort these alphabetically per i18n
-      {
-        label: 'Age',
-        value: CriteriaTerminalType.AGE,
-      },
-      {
-        label: 'Amount',
-        value: CriteriaTerminalType.AMOUNT,
-      },
-      {
-        label: 'Fee/fine type',
-        value: CriteriaTerminalType.FEE_FINE_TYPE,
-      },
-      {
-        label: 'Item location',
-        value: CriteriaTerminalType.LOCATION,
-      },
-      {
-        label: 'Item service point',
-        value: CriteriaTerminalType.SERVICE_POINT,
-      },
+      ...(patronOnly
+        ? []
+        : [
+            {
+              label: 'Age',
+              value: CriteriaTerminalType.AGE,
+            },
+            {
+              label: 'Amount',
+              value: CriteriaTerminalType.AMOUNT,
+            },
+            {
+              label: 'Fee/fine type',
+              value: CriteriaTerminalType.FEE_FINE_TYPE,
+            },
+            {
+              label: 'Item location',
+              value: CriteriaTerminalType.LOCATION,
+            },
+            {
+              label: 'Item service point',
+              value: CriteriaTerminalType.SERVICE_POINT,
+            },
+          ]),
       {
         label: 'Patron group',
         value: CriteriaTerminalType.PATRON_GROUP,
@@ -79,7 +85,7 @@ export default function CriteriaCardSelect({
     }
 
     return options;
-  }, [root]);
+  }, [root, patronOnly]);
 
   return (
     <Field name={name} defaultValue={selectDefaultValue}>

--- a/src/components/Criteria/CriteriaCardToolbox.test.tsx
+++ b/src/components/Criteria/CriteriaCardToolbox.test.tsx
@@ -10,13 +10,11 @@ import {
 import FormValues from '../../types/FormValues';
 import CriteriaCardToolbox from './CriteriaCardToolbox';
 
-const noop = () => ({});
-
 describe('Criteria card toolbox', () => {
   it('Default outer type results in no buttons', () => {
     render(
       withIntlConfiguration(
-        <Form<FormValues> mutators={{ ...arrayMutators }} onSubmit={noop}>
+        <Form<FormValues> mutators={{ ...arrayMutators }} onSubmit={jest.fn()}>
           {() => <CriteriaCardToolbox prefix="criteria." root alone />}
         </Form>
       )
@@ -34,7 +32,7 @@ describe('Criteria card toolbox', () => {
       withIntlConfiguration(
         <Form<FormValues>
           mutators={{ ...arrayMutators }}
-          onSubmit={noop}
+          onSubmit={jest.fn()}
           initialValues={{ criteria: { type } }}
         >
           {() => <CriteriaCardToolbox prefix="criteria." root alone />}
@@ -55,7 +53,7 @@ describe('Criteria card toolbox', () => {
       withIntlConfiguration(
         <Form<FormValues>
           mutators={{ ...arrayMutators }}
-          onSubmit={noop}
+          onSubmit={jest.fn()}
           initialValues={{ criteria: { type } }}
         >
           {() => (

--- a/src/components/Criteria/CriteriaCardToolbox.test.tsx
+++ b/src/components/Criteria/CriteriaCardToolbox.test.tsx
@@ -4,8 +4,8 @@ import React from 'react';
 import { Form } from 'react-final-form';
 import withIntlConfiguration from '../../test/util/withIntlConfiguration';
 import {
-  CriteriaCardGroupType,
-  CriteriaCardTerminalType,
+  CriteriaGroupType,
+  CriteriaTerminalType,
 } from '../../types/CriteriaTypes';
 import FormValues from '../../types/FormValues';
 import CriteriaCardToolbox from './CriteriaCardToolbox';
@@ -26,9 +26,9 @@ describe('Criteria card toolbox', () => {
   });
 
   it.each([
-    CriteriaCardGroupType.ALL_OF,
-    CriteriaCardGroupType.ANY_OF,
-    CriteriaCardGroupType.NONE_OF,
+    CriteriaGroupType.ALL_OF,
+    CriteriaGroupType.ANY_OF,
+    CriteriaGroupType.NONE_OF,
   ])('Outer group type %s results in only add', (type) => {
     render(
       withIntlConfiguration(
@@ -47,9 +47,9 @@ describe('Criteria card toolbox', () => {
   });
 
   it.each([
-    CriteriaCardGroupType.ALL_OF,
-    CriteriaCardGroupType.ANY_OF,
-    CriteriaCardGroupType.NONE_OF,
+    CriteriaGroupType.ALL_OF,
+    CriteriaGroupType.ANY_OF,
+    CriteriaGroupType.NONE_OF,
   ])('Inner group type %s results in add and delete', (type) => {
     render(
       withIntlConfiguration(
@@ -76,9 +76,9 @@ describe('Criteria card toolbox', () => {
   });
 
   it.each([
-    CriteriaCardGroupType.ALL_OF,
-    CriteriaCardGroupType.ANY_OF,
-    CriteriaCardGroupType.NONE_OF,
+    CriteriaGroupType.ALL_OF,
+    CriteriaGroupType.ANY_OF,
+    CriteriaGroupType.NONE_OF,
   ])('Inner group type alone %s results in add and disabled delete', (type) => {
     render(
       withIntlConfiguration(
@@ -98,7 +98,7 @@ describe('Criteria card toolbox', () => {
     expect(screen.getByRole('button', { name: 'trash' })).toBeDisabled;
   });
 
-  it.each([CriteriaCardTerminalType.AGE, CriteriaCardTerminalType.LOCATION])(
+  it.each([CriteriaTerminalType.AGE, CriteriaTerminalType.LOCATION])(
     'Inner type alone %s has disabled delete',
     (type) => {
       render(
@@ -121,7 +121,7 @@ describe('Criteria card toolbox', () => {
     }
   );
 
-  it.each([CriteriaCardTerminalType.AGE, CriteriaCardTerminalType.LOCATION])(
+  it.each([CriteriaTerminalType.AGE, CriteriaTerminalType.LOCATION])(
     'Inner type not alone %s has enabled delete',
     (type) => {
       render(

--- a/src/components/Criteria/CriteriaCardToolbox.test.tsx
+++ b/src/components/Criteria/CriteriaCardToolbox.test.tsx
@@ -82,7 +82,7 @@ describe('Criteria card toolbox', () => {
       withIntlConfiguration(
         <Form<FormValues>
           mutators={{ ...arrayMutators }}
-          onSubmit={noop}
+          onSubmit={jest.fn()}
           initialValues={{ criteria: { type } }}
         >
           {() => <CriteriaCardToolbox prefix="criteria." root={false} alone />}
@@ -103,7 +103,7 @@ describe('Criteria card toolbox', () => {
         withIntlConfiguration(
           <Form<FormValues>
             mutators={{ ...arrayMutators }}
-            onSubmit={noop}
+            onSubmit={jest.fn()}
             initialValues={{ criteria: { type } }}
           >
             {() => (
@@ -126,7 +126,7 @@ describe('Criteria card toolbox', () => {
         withIntlConfiguration(
           <Form<FormValues>
             mutators={{ ...arrayMutators }}
-            onSubmit={noop}
+            onSubmit={jest.fn()}
             initialValues={{ criteria: { type } }}
           >
             {() => (

--- a/src/components/Criteria/CriteriaCardToolbox.tsx
+++ b/src/components/Criteria/CriteriaCardToolbox.tsx
@@ -3,8 +3,8 @@ import React, { useCallback } from 'react';
 import { useField } from 'react-final-form';
 import { useFieldArray } from 'react-final-form-arrays';
 import {
-  CriteriaCardGroupType,
-  CriteriaCardTerminalType,
+  CriteriaGroupType,
+  CriteriaTerminalType,
   CriteriaGroup,
   CriteriaTerminal,
 } from '../../types/CriteriaTypes';
@@ -22,12 +22,12 @@ export default function CriteriaCardToolbox({
   alone = false,
   onRemove,
 }: CriteriaCardToolboxProps) {
-  const type = useField<CriteriaCardGroupType | CriteriaCardTerminalType>(
+  const type = useField<CriteriaGroupType | CriteriaTerminalType>(
     `${prefix}type`,
     // format ensures undefined is treated as default (pass)
     {
       subscription: { value: true },
-      format: (value) => value || CriteriaCardTerminalType.PASS,
+      format: (value) => value || CriteriaTerminalType.PASS,
     }
   ).input.value;
   const criteria = useFieldArray<CriteriaGroup | CriteriaTerminal>(
@@ -36,7 +36,7 @@ export default function CriteriaCardToolbox({
 
   const addCallback = useCallback(() => {
     criteria.fields.push({
-      type: CriteriaCardGroupType.ALL_OF,
+      type: CriteriaGroupType.ALL_OF,
       criteria: [],
     });
   }, [criteria]);
@@ -45,10 +45,10 @@ export default function CriteriaCardToolbox({
     <div>
       {(
         [
-          CriteriaCardGroupType.ALL_OF,
-          CriteriaCardGroupType.ANY_OF,
-          CriteriaCardGroupType.NONE_OF,
-        ] as (CriteriaCardGroupType | CriteriaCardTerminalType)[]
+          CriteriaGroupType.ALL_OF,
+          CriteriaGroupType.ANY_OF,
+          CriteriaGroupType.NONE_OF,
+        ] as (CriteriaGroupType | CriteriaTerminalType)[]
       ).includes(type) && <IconButton icon="plus-sign" onClick={addCallback} />}
       {!root && <IconButton icon="trash" onClick={onRemove} disabled={alone} />}
     </div>

--- a/src/components/Criteria/CriteriaLocation.test.tsx
+++ b/src/components/Criteria/CriteriaLocation.test.tsx
@@ -13,7 +13,7 @@ const getResponse = jest.fn((endpoint: string) => {
     return {
       locinsts: [
         {
-          id: '40ee00ca-a518-4b49-be01-0638d0a4ac57',
+          id: 'institutionId',
           name: 'Test institution',
         },
       ],
@@ -22,19 +22,19 @@ const getResponse = jest.fn((endpoint: string) => {
     return {
       loccamps: [
         {
-          id: '62cf76b7-cca5-4d33-9217-edf42ce1a848',
+          id: 'campusId1',
           name: 'Matching campus 1',
-          institutionId: '40ee00ca-a518-4b49-be01-0638d0a4ac57',
+          institutionId: 'institutionId',
         },
         {
-          id: 'f239fd5d-6e62-52fe-b640-28e853aa2abd',
+          id: 'campusId2',
           name: 'Matching campus 2',
-          institutionId: '40ee00ca-a518-4b49-be01-0638d0a4ac57',
+          institutionId: 'institutionId',
         },
         {
-          id: '62cf76b7-cca5-4d33-9217-edf42ce1a848',
+          id: 'campusIdIrrelevant',
           name: 'Non-matching campus',
-          institutionId: 'a83bdecc-5e33-58a7-8f84-177af3edad66',
+          institutionId: 'institutionIrrelevant',
         },
       ],
     };
@@ -42,14 +42,14 @@ const getResponse = jest.fn((endpoint: string) => {
     return {
       loclibs: [
         {
-          id: '5d78803e-ca04-4b4a-aeae-2c63b924518b',
+          id: 'libraryId',
           name: 'Matching library',
-          campusId: '62cf76b7-cca5-4d33-9217-edf42ce1a848',
+          campusId: 'campusId1',
         },
         {
-          id: 'c2549bb4-19c7-4fcc-8b52-39e612fb7dbe',
+          id: 'libraryIdIrrelevant',
           name: 'Non-matching library',
-          campusId: '470ff1dd-937a-4195-bf9e-06bcfcd135df',
+          campusId: 'campusIdIrrelevant',
         },
       ],
     };
@@ -57,19 +57,19 @@ const getResponse = jest.fn((endpoint: string) => {
     return {
       locations: [
         {
-          id: 'fcd64ce1-6995-48f0-840e-89ffa2288371',
+          id: 'locationId1',
           name: 'Matching location 1',
-          libraryId: '5d78803e-ca04-4b4a-aeae-2c63b924518b',
+          libraryId: 'libraryId',
         },
         {
-          id: '758258bc-ecc1-41b8-abca-f7b610822ffd',
+          id: 'locationId2',
           name: 'Matching location 2',
-          libraryId: '5d78803e-ca04-4b4a-aeae-2c63b924518b',
+          libraryId: 'libraryId',
         },
         {
-          id: '184aae84-a5bf-4c6a-85ba-4a7c73026cd5',
+          id: 'locationIrrelevant',
           name: 'Non-matching location',
-          libraryId: 'c2549bb4-19c7-4fcc-8b52-39e612fb7dbe',
+          libraryId: 'libraryIdIrrelevant',
         },
       ],
     };
@@ -193,10 +193,10 @@ it('Location criteria displays appropriate form', async () => {
   expect(submitter).toHaveBeenCalledWith({
     criteria: {
       type: 'Location',
-      institutionId: '40ee00ca-a518-4b49-be01-0638d0a4ac57',
-      campusId: '62cf76b7-cca5-4d33-9217-edf42ce1a848',
-      libraryId: '5d78803e-ca04-4b4a-aeae-2c63b924518b',
-      locationId: 'fcd64ce1-6995-48f0-840e-89ffa2288371',
+      institutionId: 'institutionId',
+      campusId: 'campusId1',
+      libraryId: 'libraryId',
+      locationId: 'locationId1',
     },
   });
 });

--- a/src/components/Token/Data/ConstantConditionalToken.test.tsx
+++ b/src/components/Token/Data/ConstantConditionalToken.test.tsx
@@ -6,8 +6,8 @@ import { Form } from 'react-final-form';
 import withIntlConfiguration from '../../../test/util/withIntlConfiguration';
 import {
   ComparisonOperator,
-  CriteriaCardGroupType,
-  CriteriaCardTerminalType,
+  CriteriaGroupType,
+  CriteriaTerminalType,
 } from '../../../types/CriteriaTypes';
 import { DataTokenType } from '../../../types/TokenTypes';
 import DataTokenCardBody from './DataTokenCardBody';
@@ -27,12 +27,12 @@ describe('Constant conditional token', () => {
                 type: DataTokenType.CONSTANT_CONDITIONAL,
                 conditions: [
                   {
-                    type: CriteriaCardTerminalType.AGE,
+                    type: CriteriaTerminalType.AGE,
                     numDays: '10',
                     value: 'if value 1',
                   },
                   {
-                    type: CriteriaCardTerminalType.AMOUNT,
+                    type: CriteriaTerminalType.AMOUNT,
                     operator: ComparisonOperator.GREATER_THAN,
                     amountDollars: '20',
                     value: 'if value 2',
@@ -69,18 +69,18 @@ describe('Constant conditional token', () => {
           type: DataTokenType.CONSTANT_CONDITIONAL,
           conditions: [
             {
-              type: CriteriaCardTerminalType.AGE,
+              type: CriteriaTerminalType.AGE,
               numDays: '10',
               value: 'if value 1',
             },
             {
-              type: CriteriaCardTerminalType.AMOUNT,
+              type: CriteriaTerminalType.AMOUNT,
               operator: ComparisonOperator.GREATER_THAN,
               amountDollars: '20',
               value: 'if value 2',
             },
             {
-              type: CriteriaCardGroupType.ALL_OF,
+              type: CriteriaGroupType.ALL_OF,
               value: 'if value 3',
             },
           ],

--- a/src/components/Token/Data/ConstantConditionalToken.test.tsx
+++ b/src/components/Token/Data/ConstantConditionalToken.test.tsx
@@ -13,80 +13,122 @@ import { DataTokenType } from '../../../types/TokenTypes';
 import DataTokenCardBody from './DataTokenCardBody';
 
 describe('Constant conditional token', () => {
-  describe('buttons work as expected', () => {
+  it('add works as expected', async () => {
     const submitter = jest.fn();
 
-    beforeEach(() => {
-      render(
-        withIntlConfiguration(
-          <Form
-            mutators={{ ...arrayMutators }}
-            onSubmit={(v) => submitter(v)}
-            initialValues={{
-              test: {
-                type: DataTokenType.CONSTANT_CONDITIONAL,
-                conditions: [
-                  {
-                    type: CriteriaTerminalType.AGE,
-                    numDays: '10',
-                    value: 'if value 1',
-                  },
-                  {
-                    type: CriteriaTerminalType.AMOUNT,
-                    operator: ComparisonOperator.GREATER_THAN,
-                    amountDollars: '20',
-                    value: 'if value 2',
-                  },
-                ],
-                else: 'fallback else',
-              },
-            }}
-          >
-            {({ handleSubmit }) => (
-              <form onSubmit={handleSubmit}>
-                <DataTokenCardBody name="test" />
-                <button type="submit">Submit</button>
-              </form>
-            )}
-          </Form>
-        )
-      );
+    render(
+      withIntlConfiguration(
+        <Form
+          mutators={{ ...arrayMutators }}
+          onSubmit={(v) => submitter(v)}
+          initialValues={{
+            test: {
+              type: DataTokenType.CONSTANT_CONDITIONAL,
+              conditions: [
+                {
+                  type: CriteriaTerminalType.AGE,
+                  numDays: '10',
+                  value: 'if value 1',
+                },
+                {
+                  type: CriteriaTerminalType.AMOUNT,
+                  operator: ComparisonOperator.GREATER_THAN,
+                  amountDollars: '20',
+                  value: 'if value 2',
+                },
+              ],
+              else: 'fallback else',
+            },
+          }}
+        >
+          {({ handleSubmit }) => (
+            <form onSubmit={handleSubmit}>
+              <DataTokenCardBody name="test" />
+              <button type="submit">Submit</button>
+            </form>
+          )}
+        </Form>
+      )
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Add condition' })
+    );
+    await userEvent.type(
+      screen.getAllByRole('textbox', { name: 'Then use:' })[2],
+      'if value 3'
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(submitter).toHaveBeenLastCalledWith({
+      test: {
+        type: DataTokenType.CONSTANT_CONDITIONAL,
+        conditions: [
+          {
+            type: CriteriaTerminalType.AGE,
+            numDays: '10',
+            value: 'if value 1',
+          },
+          {
+            type: CriteriaTerminalType.AMOUNT,
+            operator: ComparisonOperator.GREATER_THAN,
+            amountDollars: '20',
+            value: 'if value 2',
+          },
+          {
+            type: CriteriaGroupType.ALL_OF,
+            value: 'if value 3',
+          },
+        ],
+        else: 'fallback else',
+      },
     });
+  });
 
-    it('add works as expected', async () => {
-      await userEvent.click(
-        screen.getByRole('button', { name: 'Add condition' })
-      );
-      await userEvent.type(
-        screen.getAllByRole('textbox', { name: 'Then use:' })[2],
-        'if value 3'
-      );
+  describe('aggregate is respected', () => {
+    test.each([
+      [undefined, true],
+      [true, false],
+      [false, true],
+    ])(
+      'if aggregate=%s then item/etc options should be present=%s',
+      (aggregate, shouldHaveNonAggregateCriteria) => {
+        render(
+          withIntlConfiguration(
+            <Form
+              mutators={{ ...arrayMutators }}
+              onSubmit={jest.fn()}
+              initialValues={{
+                aggregate,
+                test: {
+                  type: DataTokenType.CONSTANT_CONDITIONAL,
+                  conditions: [
+                    {
+                      type: CriteriaTerminalType.AGE,
+                      numDays: '10',
+                      value: 'if value 1',
+                    },
+                  ],
+                  else: 'fallback else',
+                },
+              }}
+            >
+              {() => <DataTokenCardBody name="test" />}
+            </Form>
+          )
+        );
 
-      await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
-
-      expect(submitter).toHaveBeenLastCalledWith({
-        test: {
-          type: DataTokenType.CONSTANT_CONDITIONAL,
-          conditions: [
-            {
-              type: CriteriaTerminalType.AGE,
-              numDays: '10',
-              value: 'if value 1',
-            },
-            {
-              type: CriteriaTerminalType.AMOUNT,
-              operator: ComparisonOperator.GREATER_THAN,
-              amountDollars: '20',
-              value: 'if value 2',
-            },
-            {
-              type: CriteriaGroupType.ALL_OF,
-              value: 'if value 3',
-            },
-          ],
-          else: 'fallback else',
-        },
-      });
-    });
+        if (shouldHaveNonAggregateCriteria) {
+          expect(
+            screen.getByRole('option', { name: 'Item location' })
+          ).toBeInTheDocument();
+        } else {
+          expect(
+            screen.queryByRole('option', { name: 'Item location' })
+          ).toBeNull();
+        }
+      }
+    );
   });
 });

--- a/src/components/Token/Data/ConstantConditionalToken.tsx
+++ b/src/components/Token/Data/ConstantConditionalToken.tsx
@@ -1,6 +1,6 @@
 import { Button, Card, Col, TextField } from '@folio/stripes/components';
 import React from 'react';
-import { Field } from 'react-final-form';
+import { Field, useField } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
 import {
   CriteriaGroupType,
@@ -15,6 +15,11 @@ export default function ConstantConditionalToken({
 }: {
   prefix: string;
 }) {
+  const aggregate = useField<boolean>('aggregate', {
+    subscription: { value: true },
+    format: (value) => value ?? false,
+  }).input.value;
+
   return (
     <FieldArray<CriteriaGroup | CriteriaTerminal>
       name={`${prefix}conditions`}
@@ -28,6 +33,7 @@ export default function ConstantConditionalToken({
                 key={name}
                 index={index}
                 conditionName={name}
+                patronOnly={aggregate}
                 fieldArrayName={`${prefix}conditions`}
               >
                 <Field name={`${name}.value`}>

--- a/src/components/Token/Data/ConstantConditionalToken.tsx
+++ b/src/components/Token/Data/ConstantConditionalToken.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { Field } from 'react-final-form';
 import { FieldArray } from 'react-final-form-arrays';
 import {
-  CriteriaCardGroupType,
-  CriteriaCardTerminalType,
+  CriteriaGroupType,
+  CriteriaTerminalType,
   CriteriaGroup,
   CriteriaTerminal,
 } from '../../../types/CriteriaTypes';
@@ -18,7 +18,7 @@ export default function ConstantConditionalToken({
   return (
     <FieldArray<CriteriaGroup | CriteriaTerminal>
       name={`${prefix}conditions`}
-      defaultValue={[{ type: CriteriaCardTerminalType.PATRON_GROUP }]}
+      defaultValue={[{ type: CriteriaTerminalType.PATRON_GROUP }]}
     >
       {({ fields }) => (
         <>
@@ -59,9 +59,7 @@ export default function ConstantConditionalToken({
           </Col>
           <Col xs={12}>
             <Button
-              onClick={() =>
-                fields.push({ type: CriteriaCardGroupType.ALL_OF })
-              }
+              onClick={() => fields.push({ type: CriteriaGroupType.ALL_OF })}
             >
               Add condition
             </Button>

--- a/src/components/Token/Data/DataTokenCard.test.tsx
+++ b/src/components/Token/Data/DataTokenCard.test.tsx
@@ -3,11 +3,8 @@ import arrayMutators from 'final-form-arrays';
 import React from 'react';
 import { Form } from 'react-final-form';
 import withIntlConfiguration from '../../../test/util/withIntlConfiguration';
+import { DataTokenType } from '../../../types/TokenTypes';
 import DataTokenCard from './DataTokenCard';
-import {
-  DataTokenType,
-  HeaderFooterTokenType,
-} from '../../../types/TokenTypes';
 
 describe('Data token card', () => {
   test('has good default value', () => {

--- a/src/components/Token/Data/DataTokenCardBody.empty.test.tsx
+++ b/src/components/Token/Data/DataTokenCardBody.empty.test.tsx
@@ -12,6 +12,7 @@ test.each([
   [DataTokenType.NEWLINE_MICROSOFT, true],
   [DataTokenType.TAB, true],
   [DataTokenType.COMMA, true],
+  [DataTokenType.AGGREGATE_COUNT, true],
 
   [DataTokenType.ARBITRARY_TEXT, false],
   [DataTokenType.SPACE, false],
@@ -32,6 +33,7 @@ test.each([
   DataTokenType.NEWLINE_MICROSOFT,
   DataTokenType.TAB,
   DataTokenType.COMMA,
+  DataTokenType.AGGREGATE_COUNT,
 ])('Card bodies for type %s result in empty div', (type) => {
   const { container } = render(
     withIntlConfiguration(

--- a/src/components/Token/Data/DataTokenCardBody.tsx
+++ b/src/components/Token/Data/DataTokenCardBody.tsx
@@ -17,6 +17,8 @@ export const EMPTY_BODY_TYPES = [
   DataTokenType.NEWLINE,
   DataTokenType.NEWLINE_MICROSOFT,
   DataTokenType.TAB,
+
+  DataTokenType.AGGREGATE_COUNT,
 ];
 
 export function isDataBodyEmpty(type: DataTokenType | undefined) {
@@ -50,6 +52,7 @@ export default function DataTokenCardBody({ name }: { name: string }) {
           </Row>
         );
 
+      case DataTokenType.AGGREGATE_TOTAL:
       case DataTokenType.ACCOUNT_AMOUNT:
         return (
           <Row>

--- a/src/components/Token/Data/DataTypeSelect.test.tsx
+++ b/src/components/Token/Data/DataTypeSelect.test.tsx
@@ -3,10 +3,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Form } from 'react-final-form';
 import withIntlConfiguration from '../../../test/util/withIntlConfiguration';
-import {
-  DataTokenType,
-  HeaderFooterTokenType,
-} from '../../../types/TokenTypes';
+import { DataTokenType } from '../../../types/TokenTypes';
 import DataTypeSelect from './DataTypeSelect';
 
 describe('Data token type selection', () => {
@@ -54,5 +51,58 @@ describe('Data token type selection', () => {
     );
 
     expect(screen.getByRole('combobox')).toHaveDisplayValue('Fee/fine type');
+  });
+
+  it.each([
+    ['Newline (LF)', undefined],
+    ['Newline (LF)', false],
+    ['Newline (LF)', true],
+
+    ['Item info', undefined],
+    ['Item info', false],
+
+    ['Total amount', true],
+    ['Number of accounts', true],
+  ])('has %s when aggregate=%s', (optionName, aggregate) => {
+    render(
+      withIntlConfiguration(
+        <Form onSubmit={() => ({})} initialValues={{ aggregate }}>
+          {({ handleSubmit }) => (
+            <form onSubmit={handleSubmit}>
+              <DataTypeSelect name="test" />
+              <button type="submit">Submit</button>
+            </form>
+          )}
+        </Form>
+      )
+    );
+
+    expect(
+      screen.getByRole('option', { name: optionName })
+    ).toBeInTheDocument();
+  });
+
+  it.each([
+    ['Item info', true],
+
+    ['Total amount', undefined],
+    ['Total amount', false],
+    ['Number of accounts', undefined],
+    ['Number of accounts', false],
+  ])('does not have %s when aggregate=%s', (optionName, aggregate) => {
+    render(
+      withIntlConfiguration(
+        <Form onSubmit={() => ({})} initialValues={{ aggregate }}>
+          {({ handleSubmit }) => (
+            <form onSubmit={handleSubmit}>
+              <DataTypeSelect name="test" />
+              <button type="submit">Submit</button>
+            </form>
+          )}
+        </Form>
+      )
+    );
+
+    expect(screen.queryByRole('option', { name: optionName })).toBeNull();
   });
 });

--- a/src/components/Token/Data/DataTypeSelect.tsx
+++ b/src/components/Token/Data/DataTypeSelect.tsx
@@ -1,9 +1,97 @@
-import React from 'react';
-import { DataTokenType } from '../../../types/TokenTypes';
 import { Select } from '@folio/stripes/components';
-import { Field } from 'react-final-form';
+import React from 'react';
+import { Field, useField } from 'react-final-form';
+import { DataTokenType } from '../../../types/TokenTypes';
+
+const ALWAYS_AVAILABLE_OPTIONS = [
+  {
+    label: 'Newline (LF)',
+    value: DataTokenType.NEWLINE,
+  },
+  {
+    label: 'Newline (Microsoft, CRLF)',
+    value: DataTokenType.NEWLINE_MICROSOFT,
+  },
+  {
+    label: 'Tab',
+    value: DataTokenType.TAB,
+  },
+  {
+    label: 'Comma',
+    value: DataTokenType.COMMA,
+  },
+  {
+    label: 'Whitespace',
+    value: DataTokenType.SPACE,
+  },
+
+  {
+    label: '',
+    value: DataTokenType.NEWLINE,
+    disabled: true,
+  },
+
+  {
+    label: 'Arbitrary text',
+    value: DataTokenType.ARBITRARY_TEXT,
+  },
+  {
+    label: 'Current date',
+    value: DataTokenType.CURRENT_DATE,
+  },
+  {
+    label: 'Conditional text',
+    value: DataTokenType.CONSTANT_CONDITIONAL,
+  },
+
+  {
+    label: '',
+    value: DataTokenType.NEWLINE,
+    disabled: true,
+  },
+
+  {
+    label: 'User info',
+    value: DataTokenType.USER_DATA,
+  },
+];
+
+const NON_AGGREGATE_OPTIONS = [
+  {
+    label: 'Account amount',
+    value: DataTokenType.ACCOUNT_AMOUNT,
+  },
+  {
+    label: 'Account date',
+    value: DataTokenType.ACCOUNT_DATE,
+  },
+  {
+    label: 'Fee/fine type',
+    value: DataTokenType.FEE_FINE_TYPE,
+  },
+  {
+    label: 'Item info',
+    value: DataTokenType.ITEM_INFO,
+  },
+];
+
+const AGGREGATE_OPTIONS = [
+  {
+    label: 'Total amount',
+    value: DataTokenType.AGGREGATE_TOTAL,
+  },
+  {
+    label: 'Number of accounts',
+    value: DataTokenType.AGGREGATE_COUNT,
+  },
+];
 
 export default function DataTypeSelect({ name }: { name: string }) {
+  const isAggregate = useField<boolean>('aggregate', {
+    subscription: { value: true },
+    format: (value) => value ?? false,
+  }).input.value;
+
   return (
     <Field name={name} defaultValue={DataTokenType.NEWLINE}>
       {(fieldProps) => (
@@ -13,72 +101,8 @@ export default function DataTypeSelect({ name }: { name: string }) {
           marginBottom0
           dataOptions={[
             // TODO: sort these alphabetically per i18n
-            {
-              label: 'Newline (LF)',
-              value: DataTokenType.NEWLINE,
-            },
-            {
-              label: 'Newline (Microsoft, CRLF)',
-              value: DataTokenType.NEWLINE_MICROSOFT,
-            },
-            {
-              label: 'Tab',
-              value: DataTokenType.TAB,
-            },
-            {
-              label: 'Comma',
-              value: DataTokenType.COMMA,
-            },
-            {
-              label: 'Whitespace',
-              value: DataTokenType.SPACE,
-            },
-
-            {
-              label: '',
-              value: DataTokenType.NEWLINE,
-              disabled: true,
-            },
-
-            {
-              label: 'Arbitrary text',
-              value: DataTokenType.ARBITRARY_TEXT,
-            },
-            {
-              label: 'Current date',
-              value: DataTokenType.CURRENT_DATE,
-            },
-            {
-              label: 'Conditional text',
-              value: DataTokenType.CONSTANT_CONDITIONAL,
-            },
-
-            {
-              label: '',
-              value: DataTokenType.NEWLINE,
-              disabled: true,
-            },
-
-            {
-              label: 'Account amount',
-              value: DataTokenType.ACCOUNT_AMOUNT,
-            },
-            {
-              label: 'Account date',
-              value: DataTokenType.ACCOUNT_DATE,
-            },
-            {
-              label: 'Fee/fine type',
-              value: DataTokenType.FEE_FINE_TYPE,
-            },
-            {
-              label: 'Item info',
-              value: DataTokenType.ITEM_INFO,
-            },
-            {
-              label: 'User info',
-              value: DataTokenType.USER_DATA,
-            },
+            ...ALWAYS_AVAILABLE_OPTIONS,
+            ...(isAggregate ? AGGREGATE_OPTIONS : NON_AGGREGATE_OPTIONS),
           ]}
         />
       )}

--- a/src/components/Token/LengthControlDrawer.tsx
+++ b/src/components/Token/LengthControlDrawer.tsx
@@ -21,6 +21,9 @@ export const TOKEN_TYPES_WITH_LENGTH_CONTROL = [
   DataTokenType.FEE_FINE_TYPE,
   DataTokenType.ITEM_INFO,
   DataTokenType.USER_DATA,
+
+  DataTokenType.AGGREGATE_COUNT,
+  DataTokenType.AGGREGATE_TOTAL,
 ];
 
 function FakeHeader() {

--- a/src/components/Token/Shared/AmountWithDecimalToken.test.tsx
+++ b/src/components/Token/Shared/AmountWithDecimalToken.test.tsx
@@ -14,6 +14,7 @@ describe('Aggregate total token', () => {
   it.each([
     [HeaderFooterTokenType.AGGREGATE_TOTAL, HeaderFooterCardBody],
     [DataTokenType.ACCOUNT_AMOUNT, DataTokenCardBody],
+    [DataTokenType.AGGREGATE_TOTAL, DataTokenCardBody],
   ])('displays appropriate form', async (type, Component) => {
     const submitter = jest.fn();
 

--- a/src/form/ConfigurationForm.tsx
+++ b/src/form/ConfigurationForm.tsx
@@ -76,6 +76,7 @@ function ConfigurationForm({
         <Accordion label="Transfer accounts to">
           <TransferInfoMenu />
         </Accordion>
+
         <Accordion label="Debug (form state)">
           <FormSpy subscription={{ values: true }}>
             {({ values }) => <pre>{JSON.stringify(values, undefined, 2)}</pre>}

--- a/src/form/ConfigurationForm.tsx
+++ b/src/form/ConfigurationForm.tsx
@@ -7,7 +7,7 @@ import {
 } from '@folio/stripes/components';
 import stripesFinalForm from '@folio/stripes/final-form';
 import React, { FormEvent, useCallback } from 'react';
-import { FormRenderProps, FormSpy } from 'react-final-form';
+import { FormRenderProps, FormSpy, useField } from 'react-final-form';
 import useFeeFineOwners, { FeeFineOwnerDTO } from '../api/useFeeFineOwners';
 import useFeeFineTypes, { FeeFineTypeDTO } from '../api/useFeeFineTypes';
 import useLocations, { LocationDTO } from '../api/useLocations';
@@ -47,6 +47,11 @@ function ConfigurationForm({
     [handleSubmit]
   );
 
+  const aggregateEnabled = useField<boolean>('aggregate', {
+    subscription: { value: true },
+    format: (value) => value ?? false,
+  }).input.value;
+
   return (
     <form id={FORM_ID} onSubmit={submitter}>
       <AccordionSet>
@@ -67,7 +72,11 @@ function ConfigurationForm({
         <Accordion label="Header format">
           <HeaderFooterMenu name="header" />
         </Accordion>
-        <Accordion label="Account data format">
+        <Accordion
+          label={
+            aggregateEnabled ? 'Patron data format' : 'Account data format'
+          }
+        >
           <DataTokenMenu />
         </Accordion>
         <Accordion label="Footer format">

--- a/src/form/ConfigurationForm.tsx
+++ b/src/form/ConfigurationForm.tsx
@@ -23,6 +23,7 @@ import useLibraries from '../api/useLibraries';
 import HeaderFooterMenu from './sections/HeaderFooterMenu';
 import DataTokenMenu from './sections/DataTokenMenu';
 import TransferInfoMenu from './sections/TransferInfoMenu';
+import AggregateMenu from './sections/AggregateMenu';
 
 export const FORM_ID = 'ui-plugin-bursar-export-form';
 
@@ -61,7 +62,7 @@ function ConfigurationForm({
           <CriteriaMenu />
         </Accordion>
         <Accordion label="Aggregate by patron">
-          <p>Settings go here...</p>
+          <AggregateMenu />
         </Accordion>
         <Accordion label="Header format">
           <HeaderFooterMenu name="header" />

--- a/src/form/ConfigurationForm.tsx
+++ b/src/form/ConfigurationForm.tsx
@@ -60,6 +60,9 @@ function ConfigurationForm({
         <Accordion label="Criteria">
           <CriteriaMenu />
         </Accordion>
+        <Accordion label="Aggregate by patron">
+          <p>Settings go here...</p>
+        </Accordion>
         <Accordion label="Header format">
           <HeaderFooterMenu name="header" />
         </Accordion>

--- a/src/form/sections/AggregateMenu.test.tsx
+++ b/src/form/sections/AggregateMenu.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import arrayMutators from 'final-form-arrays';
+import React from 'react';
+import { Form } from 'react-final-form';
+import withIntlConfiguration from '../../test/util/withIntlConfiguration';
+import FormValues from '../../types/FormValues';
+import { HeaderFooterTokenType } from '../../types/TokenTypes';
+import HeaderFooterMenu from './HeaderFooterMenu';
+import AggregateMenu from './AggregateMenu';
+import { CriteriaAggregateType } from '../../types/CriteriaTypes';
+
+test('Aggregate menu displays criteria on check', async () => {
+  const submitter = jest.fn();
+
+  render(
+    withIntlConfiguration(
+      <Form<FormValues> onSubmit={(v) => submitter(v)}>
+        {({ handleSubmit }) => (
+          <form onSubmit={handleSubmit}>
+            <AggregateMenu />
+            <button type="submit">Submit</button>
+          </form>
+        )}
+      </Form>
+    )
+  );
+
+  // do not display criteria initially
+  expect(screen.queryByRole('combobox')).toBeNull();
+
+  await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+  expect(submitter).toHaveBeenCalledWith({
+    aggregate: false,
+  });
+
+  await userEvent.click(screen.getByRole('checkbox'));
+  expect(await screen.findByRole('combobox')).toBeVisible();
+
+  await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+  expect(submitter).toHaveBeenCalledWith({
+    aggregate: true,
+    aggregateFilter: {
+      type: CriteriaAggregateType.PASS,
+    },
+  });
+
+  await userEvent.click(screen.getByRole('checkbox'));
+  expect(screen.queryByRole('combobox')).toBeNull();
+
+  await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+  expect(submitter).toHaveBeenCalledWith({
+    aggregate: false,
+    aggregateFilter: {
+      type: CriteriaAggregateType.PASS,
+    },
+  });
+});

--- a/src/form/sections/AggregateMenu.tsx
+++ b/src/form/sections/AggregateMenu.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function AggregateMenu() {
+  return <div />;
+}

--- a/src/form/sections/AggregateMenu.tsx
+++ b/src/form/sections/AggregateMenu.tsx
@@ -1,5 +1,30 @@
+import { Checkbox } from '@folio/stripes/components';
 import React from 'react';
+import { Field, useField } from 'react-final-form';
 
 export default function AggregateMenu() {
-  return <div />;
+  const isAggregateEnabled = useField<boolean>('aggregate', {
+    subscription: { value: true },
+    format: (value) => value ?? false,
+  }).input.value;
+
+  return (
+    <div>
+      <Field name="aggregate" type="checkbox" defaultValue={false}>
+        {(fieldProps) => (
+          <Checkbox {...fieldProps} fullWidth label="Group data by patron" />
+        )}
+      </Field>
+      <p
+        style={{
+          margin: 0,
+        }}
+      >
+        <i>
+          If enabled, each output row will correspond to a single patron with
+          all of their accounts, rather than just a single account.
+        </i>
+      </p>
+    </div>
+  );
 }

--- a/src/form/sections/AggregateMenu.tsx
+++ b/src/form/sections/AggregateMenu.tsx
@@ -1,6 +1,7 @@
-import { Checkbox } from '@folio/stripes/components';
+import { Card, Checkbox, Label } from '@folio/stripes/components';
 import React from 'react';
 import { Field, useField } from 'react-final-form';
+import AggregateCriteriaCard from '../../components/AggregateCriteria/AggregateCriteriaCard';
 
 export default function AggregateMenu() {
   const isAggregateEnabled = useField<boolean>('aggregate', {
@@ -15,16 +16,14 @@ export default function AggregateMenu() {
           <Checkbox {...fieldProps} fullWidth label="Group data by patron" />
         )}
       </Field>
-      <p
-        style={{
-          margin: 0,
-        }}
-      >
+      <p>
         <i>
           If enabled, each output row will correspond to a single patron with
           all of their accounts, rather than just a single account.
         </i>
       </p>
+
+      {isAggregateEnabled && <AggregateCriteriaCard />}
     </div>
   );
 }

--- a/src/form/sections/AggregateMenu.tsx
+++ b/src/form/sections/AggregateMenu.tsx
@@ -1,4 +1,4 @@
-import { Card, Checkbox, Label } from '@folio/stripes/components';
+import { Checkbox } from '@folio/stripes/components';
 import React from 'react';
 import { Field, useField } from 'react-final-form';
 import AggregateCriteriaCard from '../../components/AggregateCriteria/AggregateCriteriaCard';

--- a/src/form/sections/CriteriaMenu.buttons.test.tsx
+++ b/src/form/sections/CriteriaMenu.buttons.test.tsx
@@ -4,7 +4,7 @@ import arrayMutators from 'final-form-arrays';
 import React from 'react';
 import { Form } from 'react-final-form';
 import withIntlConfiguration from '../../test/util/withIntlConfiguration';
-import { CriteriaCardGroupType } from '../../types/CriteriaTypes';
+import { CriteriaGroupType } from '../../types/CriteriaTypes';
 import FormValues from '../../types/FormValues';
 import CriteriaMenu from './CriteriaMenu';
 
@@ -31,17 +31,17 @@ describe('Buttons work as expected', () => {
   }
 
   it('Outer add button works as expected', async () => {
-    renderWithValue({ type: CriteriaCardGroupType.ALL_OF });
+    renderWithValue({ type: CriteriaGroupType.ALL_OF });
 
     await userEvent.click(screen.getByRole('button', { name: 'plus-sign' }));
     await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
 
     expect(submitter).toHaveBeenLastCalledWith({
       criteria: {
-        type: CriteriaCardGroupType.ALL_OF,
+        type: CriteriaGroupType.ALL_OF,
         criteria: [
           {
-            type: CriteriaCardGroupType.ALL_OF,
+            type: CriteriaGroupType.ALL_OF,
             criteria: [],
           },
         ],
@@ -51,8 +51,8 @@ describe('Buttons work as expected', () => {
 
   it('Inner add button works as expected', async () => {
     renderWithValue({
-      type: CriteriaCardGroupType.ALL_OF,
-      criteria: [{ type: CriteriaCardGroupType.ANY_OF, criteria: [] }],
+      type: CriteriaGroupType.ALL_OF,
+      criteria: [{ type: CriteriaGroupType.ANY_OF, criteria: [] }],
     });
 
     await userEvent.click(
@@ -64,13 +64,13 @@ describe('Buttons work as expected', () => {
 
     expect(submitter).toHaveBeenLastCalledWith({
       criteria: {
-        type: CriteriaCardGroupType.ALL_OF,
+        type: CriteriaGroupType.ALL_OF,
         criteria: [
           {
-            type: CriteriaCardGroupType.ANY_OF,
+            type: CriteriaGroupType.ANY_OF,
             criteria: [
               {
-                type: CriteriaCardGroupType.ALL_OF,
+                type: CriteriaGroupType.ALL_OF,
                 criteria: [],
               },
             ],
@@ -82,10 +82,10 @@ describe('Buttons work as expected', () => {
 
   it('Delete button works as expected', async () => {
     renderWithValue({
-      type: CriteriaCardGroupType.ALL_OF,
+      type: CriteriaGroupType.ALL_OF,
       criteria: [
-        { type: CriteriaCardGroupType.ANY_OF, criteria: [] },
-        { type: CriteriaCardGroupType.NONE_OF, criteria: [] },
+        { type: CriteriaGroupType.ANY_OF, criteria: [] },
+        { type: CriteriaGroupType.NONE_OF, criteria: [] },
       ],
     });
 
@@ -98,10 +98,10 @@ describe('Buttons work as expected', () => {
 
     expect(submitter).toHaveBeenLastCalledWith({
       criteria: {
-        type: CriteriaCardGroupType.ALL_OF,
+        type: CriteriaGroupType.ALL_OF,
         criteria: [
           {
-            type: CriteriaCardGroupType.NONE_OF,
+            type: CriteriaGroupType.NONE_OF,
             criteria: [],
           },
         ],

--- a/src/form/sections/DataTokenMenu.test.tsx
+++ b/src/form/sections/DataTokenMenu.test.tsx
@@ -41,3 +41,39 @@ test('Add button works as expected', async () => {
     ],
   });
 });
+
+test('Add button in aggregate mode works as expected', async () => {
+  const submitter = jest.fn();
+
+  render(
+    withIntlConfiguration(
+      <Form<FormValues>
+        mutators={{ ...arrayMutators }}
+        onSubmit={(v) => submitter(v)}
+        initialValues={{ aggregate: true }}
+      >
+        {({ handleSubmit }) => (
+          <form onSubmit={handleSubmit}>
+            <DataTokenMenu />
+            <button type="submit">Submit</button>
+          </form>
+        )}
+      </Form>
+    )
+  );
+
+  await userEvent.click(screen.getByRole('button', { name: 'Add' }));
+  await userEvent.click(screen.getByRole('button', { name: 'Add' }));
+  await userEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+  await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+  expect(submitter).toHaveBeenCalledWith({
+    aggregate: true,
+    dataAggregate: [
+      { type: DataTokenType.NEWLINE },
+      { type: DataTokenType.NEWLINE },
+      { type: DataTokenType.NEWLINE },
+    ],
+  });
+});

--- a/src/form/sections/DataTokenMenu.tsx
+++ b/src/form/sections/DataTokenMenu.tsx
@@ -1,12 +1,26 @@
 import { Button } from '@folio/stripes/components';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { FieldArray } from 'react-final-form-arrays';
 import DataTokenCard from '../../components/Token/Data/DataTokenCard';
 import { DataTokenType } from '../../types/TokenTypes';
+import { useField } from 'react-final-form';
 
 export default function DataTokenMenu() {
+  const aggregate = useField<boolean>('aggregate', {
+    subscription: { value: true },
+    format: (value) => value ?? false,
+  }).input.value;
+
+  const name = useMemo(() => {
+    if (aggregate) {
+      return 'dataAggregate';
+    } else {
+      return 'data';
+    }
+  }, [aggregate]);
+
   return (
-    <FieldArray name="data">
+    <FieldArray key={name} name={name}>
       {({ fields }) => (
         <>
           {fields.map((innerName, index) => (

--- a/src/form/sections/SchedulingMenu.test.tsx
+++ b/src/form/sections/SchedulingMenu.test.tsx
@@ -6,8 +6,6 @@ import FormValues from '../../types/FormValues';
 import SchedulingFrequency from '../../types/SchedulingFrequency';
 import SchedulingMenu, { getIntervalLabel } from './SchedulingMenu';
 
-const noop = () => ({});
-
 describe('Scheduling menu', () => {
   it('Shows no interval field label when in manual mode', () => {
     expect(getIntervalLabel(SchedulingFrequency.Manual)).toBe('');
@@ -17,7 +15,7 @@ describe('Scheduling menu', () => {
     render(
       withIntlConfiguration(
         <Form<FormValues>
-          onSubmit={noop}
+          onSubmit={jest.fn()}
           initialValues={{
             scheduling: { frequency: SchedulingFrequency.Manual },
           }}
@@ -35,7 +33,7 @@ describe('Scheduling menu', () => {
     render(
       withIntlConfiguration(
         <Form<FormValues>
-          onSubmit={noop}
+          onSubmit={jest.fn()}
           initialValues={{
             scheduling: { frequency: SchedulingFrequency.Hours },
           }}
@@ -55,7 +53,7 @@ describe('Scheduling menu', () => {
     render(
       withIntlConfiguration(
         <Form<FormValues>
-          onSubmit={noop}
+          onSubmit={jest.fn()}
           initialValues={{
             scheduling: { frequency: SchedulingFrequency.Days },
           }}
@@ -80,7 +78,7 @@ describe('Scheduling menu', () => {
     render(
       withIntlConfiguration(
         <Form<FormValues>
-          onSubmit={noop}
+          onSubmit={jest.fn()}
           initialValues={{
             scheduling: { frequency: SchedulingFrequency.Weeks },
           }}

--- a/src/form/sections/TransferInfoMenu.test.tsx
+++ b/src/form/sections/TransferInfoMenu.test.tsx
@@ -6,7 +6,7 @@ import { Form } from 'react-final-form';
 import withIntlConfiguration from '../../test/util/withIntlConfiguration';
 import {
   ComparisonOperator,
-  CriteriaCardTerminalType,
+  CriteriaTerminalType,
 } from '../../types/CriteriaTypes';
 import TransferInfoMenu from './TransferInfoMenu';
 import { QueryClient, QueryClientProvider } from 'react-query';
@@ -118,7 +118,7 @@ describe('Transfer criteria menu', () => {
                   conditions: [
                     {
                       condition: {
-                        type: CriteriaCardTerminalType.AGE,
+                        type: CriteriaTerminalType.AGE,
                         numDays: '10',
                       },
                       owner: 'owner1id',
@@ -126,7 +126,7 @@ describe('Transfer criteria menu', () => {
                     },
                     {
                       condition: {
-                        type: CriteriaCardTerminalType.AMOUNT,
+                        type: CriteriaTerminalType.AMOUNT,
                         operator: ComparisonOperator.GREATER_THAN,
                         amountDollars: '20',
                       },
@@ -177,7 +177,7 @@ describe('Transfer criteria menu', () => {
           conditions: [
             {
               condition: {
-                type: CriteriaCardTerminalType.AGE,
+                type: CriteriaTerminalType.AGE,
                 numDays: '10',
               },
               owner: 'owner1id',
@@ -185,7 +185,7 @@ describe('Transfer criteria menu', () => {
             },
             {
               condition: {
-                type: CriteriaCardTerminalType.AMOUNT,
+                type: CriteriaTerminalType.AMOUNT,
                 operator: ComparisonOperator.GREATER_THAN,
                 amountDollars: '20',
               },
@@ -194,7 +194,7 @@ describe('Transfer criteria menu', () => {
             },
             {
               condition: {
-                type: CriteriaCardTerminalType.PATRON_GROUP,
+                type: CriteriaTerminalType.PATRON_GROUP,
                 patronGroupId: '1',
               },
               owner: 'owner2id',

--- a/src/form/sections/TransferInfoMenu.tsx
+++ b/src/form/sections/TransferInfoMenu.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { FieldArray } from 'react-final-form-arrays';
 import ConditionalCard from '../../components/ConditionalCard';
 import TransferAccountFields from '../../components/TransferAccountFields';
-import { CriteriaCardTerminalType } from '../../types/CriteriaTypes';
+import { CriteriaTerminalType } from '../../types/CriteriaTypes';
 
 export default function TransferInfoMenu() {
   return (
@@ -28,7 +28,7 @@ export default function TransferInfoMenu() {
           <Button
             onClick={() =>
               fields.push({
-                condition: { type: CriteriaCardTerminalType.PATRON_GROUP },
+                condition: { type: CriteriaTerminalType.PATRON_GROUP },
               })
             }
           >

--- a/src/types/CriteriaTypes.ts
+++ b/src/types/CriteriaTypes.ts
@@ -1,5 +1,5 @@
 export interface CriteriaGroup {
-  type: CriteriaCardGroupType;
+  type: CriteriaGroupType;
   criteria?: (CriteriaGroup | CriteriaTerminal)[];
 }
 
@@ -11,44 +11,59 @@ export enum ComparisonOperator {
 }
 
 export type CriteriaTerminal =
-  | { type: CriteriaCardTerminalType.PASS }
+  | { type: CriteriaTerminalType.PASS }
   | {
-      type: CriteriaCardTerminalType.AGE;
+      type: CriteriaTerminalType.AGE;
       numDays?: string;
     }
   | {
-      type: CriteriaCardTerminalType.AMOUNT;
+      type: CriteriaTerminalType.AMOUNT;
       operator?: ComparisonOperator;
       amountDollars?: string;
     }
   | {
-      type: CriteriaCardTerminalType.FEE_FINE_TYPE;
+      type: CriteriaTerminalType.FEE_FINE_TYPE;
       feeFineOwnerId?: string;
       feeFineTypeId?: string;
     }
   | {
-      type: CriteriaCardTerminalType.LOCATION;
+      type: CriteriaTerminalType.LOCATION;
       institutionId?: string;
       campusId?: string;
       libraryId?: string;
       locationId?: string;
     }
   | {
-      type: CriteriaCardTerminalType.SERVICE_POINT;
+      type: CriteriaTerminalType.SERVICE_POINT;
       servicePointId?: string;
     }
   | {
-      type: CriteriaCardTerminalType.PATRON_GROUP;
+      type: CriteriaTerminalType.PATRON_GROUP;
       patronGroupId?: string;
     };
 
-export enum CriteriaCardGroupType {
+export type CriteriaAggregate =
+  | {
+      type: CriteriaAggregateType.PASS;
+    }
+  | {
+      type: CriteriaAggregateType.NUM_ROWS;
+      operator?: ComparisonOperator;
+      amount?: string;
+    }
+  | {
+      type: CriteriaAggregateType.TOTAL_AMOUNT;
+      operator?: ComparisonOperator;
+      amountDollars?: string;
+    };
+
+export enum CriteriaGroupType {
   ALL_OF = 'Condition-AND',
   ANY_OF = 'Condition-OR',
   NONE_OF = 'Condition-NOR',
 }
 
-export enum CriteriaCardTerminalType {
+export enum CriteriaTerminalType {
   PASS = 'Pass',
 
   AGE = 'Age',
@@ -57,4 +72,10 @@ export enum CriteriaCardTerminalType {
   LOCATION = 'Location',
   SERVICE_POINT = 'ServicePoint',
   PATRON_GROUP = 'PatronGroup',
+}
+
+export enum CriteriaAggregateType {
+  PASS = 'Pass',
+  NUM_ROWS = 'NumRows',
+  TOTAL_AMOUNT = 'TotalAmount',
 }

--- a/src/types/FormValues.ts
+++ b/src/types/FormValues.ts
@@ -14,12 +14,16 @@ export default interface FormValues {
     frequency: SchedulingFrequency;
     interval?: number;
   };
+
+  criteria: CriteriaGroup | CriteriaTerminal;
+
   aggregate: boolean;
   aggregateFilter?: CriteriaAggregate;
-  criteria: CriteriaGroup | CriteriaTerminal;
+
   header?: HeaderFooterToken[];
   data?: DataToken[];
   footer?: HeaderFooterToken[];
+
   transferInfo: {
     conditions: {
       condition: CriteriaGroup | CriteriaTerminal;

--- a/src/types/FormValues.ts
+++ b/src/types/FormValues.ts
@@ -1,4 +1,8 @@
-import { CriteriaGroup, CriteriaTerminal } from './CriteriaTypes';
+import {
+  CriteriaAggregate,
+  CriteriaGroup,
+  CriteriaTerminal,
+} from './CriteriaTypes';
 import SchedulingFrequency from './SchedulingFrequency';
 import { DataToken, HeaderFooterToken } from './TokenTypes';
 
@@ -10,6 +14,8 @@ export default interface FormValues {
     frequency: SchedulingFrequency;
     interval?: number;
   };
+  aggregate: boolean;
+  aggregateFilter?: CriteriaAggregate;
   criteria: CriteriaGroup | CriteriaTerminal;
   header?: HeaderFooterToken[];
   data?: DataToken[];

--- a/src/types/FormValues.ts
+++ b/src/types/FormValues.ts
@@ -22,6 +22,7 @@ export default interface FormValues {
 
   header?: HeaderFooterToken[];
   data?: DataToken[];
+  dataAggregate?: DataToken[];
   footer?: HeaderFooterToken[];
 
   transferInfo: {

--- a/src/types/TokenTypes.ts
+++ b/src/types/TokenTypes.ts
@@ -81,6 +81,9 @@ export enum DataTokenType {
   USER_DATA = 'UserData',
 
   CONSTANT_CONDITIONAL = 'ConstantConditional',
+
+  AGGREGATE_COUNT = 'AggregateNumRows',
+  AGGREGATE_TOTAL = 'AggregateTotalAmount',
 }
 
 export type ItemAttribute =
@@ -165,4 +168,13 @@ export type DataToken =
         value: string;
       }[];
       else: string;
+    }
+  | {
+      type: DataTokenType.AGGREGATE_COUNT;
+      lengthControl?: LengthControl;
+    }
+  | {
+      type: DataTokenType.AGGREGATE_TOTAL;
+      decimal: boolean;
+      lengthControl?: LengthControl;
     };


### PR DESCRIPTION
Closes #6.

- [x] Define new types
  - [x] Form values
  - [x] Filters
  - [x] Data tokens
- [x] Add infrastructure
- [x] Create accordion with:
  - [x] Checkbox
  - [x] Aggregate filter
    - [x] Pass
    - [x] Total amount
    - [x] Number of rows
- [x] Restrict data tokens
- [x] Add new data tokens
  - [x] Num accounts
  - [x] Total value
- [x] Update constant conditional
- [x] Clean out data tokens on checkbox toggle
- [x] Clean out constant conditional non-patron on checkbox toggle

## Add/verify tests for:

### Files

- [x] AgrgegateCriteriaCard
- [x] ConditionalCard
- [x] CriteriaCard (wrt patronOnly)
- [x] CriteriaCardSelect (wrt patronOnly)
- [x] ConstantConditionalToken (wrt patronOnly)
- [x] DataTokenCardBody
- [x] DataTypeSelect
- [x] LengthControlDrawer?
- [x] AggregateMenu
- [x] DataTokenMenu

### Features

- [x] Checkbox toggles display
- [x] Checkbox clears out bad data on enable
- [x] Checkbox clears out bad data on disable
- [x] Data select changes values based on provided `aggregate` field
- [x] Data tokens show length control appropriately
- [x] Data aggregate count shows no contents
- [x] Data aggregate total shows decimal option
- [x] Aggregate criteria displays properly
- [x] Aggregate no filter
- [x] Aggregate total amount filter
- [x] Aggregate number of rows filter
- [x] Constant conditional has patron options only
